### PR TITLE
Django 4.0 and above, the url function has been removed, replace with re_path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y apt-utils vim curl apache2 apache2-utils
 RUN apt-get -y install python3 libapache2-mod-wsgi-py3
 RUN ln /usr/bin/python3 /usr/bin/python
 RUN apt-get -y install python3-pip
-RUN ln /usr/bin/pip3 /usr/bin/pip
+#RUN ln /usr/bin/pip3 /usr/bin/pip
 RUN pip install --upgrade pip
 RUN pip install django ptvsd
 ADD ./demo_site.conf /etc/apache2/sites-available/000-default.conf

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ This is a docker project to create a container with Python3, Django and Apache2.
 * docker-compose up
 
     Starts the container named django-apache2
-* Browse to http://localhost:8500
+* Browse to http://localhost:8005
 
     A sample employee list page is displayed.
 

--- a/www/django_demo_app/demo_site/app1/urls.py
+++ b/www/django_demo_app/demo_site/app1/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 app_name = 'app1'
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
+    re_path(r'^$', views.index, name='index'),
 ]

--- a/www/django_demo_app/demo_site/demo_site/urls.py
+++ b/www/django_demo_app/demo_site/demo_site/urls.py
@@ -13,10 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import re_path, include, path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^$', include('app1.urls')),
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^$', include('app1.urls')),
+    path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
fix path in the readme file
fix url with re_path